### PR TITLE
Implement DRP and Redis state persistence

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ pydantic
 structlog
 tenacity
 hvac
+redis
 
 # Blockchain & Web
 web3

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -25,6 +25,7 @@ class Settings(BaseSettings):
     LOG_LEVEL: str = "INFO"
     HEALTH_PORT: int = 8080
     SESSION_DIR: str = "/tmp/mev_og_session" # For durable state files
+    REDIS_URL: AnyUrl = "redis://localhost:6379/0"
 
     class Config:
         env_file = ".env"

--- a/src/core/logger.py
+++ b/src/core/logger.py
@@ -1,6 +1,7 @@
 # /src/core/logger.py
 import logging
 import structlog
+from structlog.contextvars import bind_contextvars
 import sentry_sdk
 from prometheus_client import Counter
 from src.core.config import settings
@@ -31,6 +32,9 @@ def configure_logging():
 
 def get_logger(name: str):
     return structlog.get_logger(name)
+
+def set_cycle_counter(counter: int):
+    bind_contextvars(cycle_counter=counter)
 
 configure_logging()
 log = get_logger("MEV-OG.System")


### PR DESCRIPTION
## Summary
- add Redis dependency
- store redis url in settings
- manage state snapshots and durable persistence in the agent
- two‑phase commit helper for strategies
- nonce locking via redis
- add cycle counter and structured log context

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: toxiproxy/pydantic/web3)*

------
https://chatgpt.com/codex/tasks/task_e_68490ed46054832cbe248d17fa733710