### PR TITLE
Implement DRP and kill-switch cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ MEMPOOL_WSS_URL="wss://mempool.example/ws"
 # --- CEX Adapter Secrets (Example for Binance) ---
 BINANCE_API_KEY="your_binance_api_key"
 BINANCE_API_SECRET="your_binance_api_secret"
+AI_MODEL_API_URL="https://api.openai.com/v1/chat/completions"
+CEX_BASE_URL="https://api.binance.com"
+MUTATION_TTL_SECONDS="3600"
 
 # --- GCP Configuration ---
 # Required for deploying to GCP Cloud Run and using Secret Manager

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         run: |
           pip install -r requirements.txt
           pip install pytest flake8
+      - name: Start Fork
+        run: ./scripts/simulate_fork.sh &
       - name: Lint with flake8
         run: flake8 src/
       - name: Run Unit Tests
@@ -45,7 +47,11 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Install dependencies
-        run: pip install -r requirements.txt && pip install pytest
+        run: pip install -r requirements.txt && pip install pytest flake8
+      - name: Lint with flake8
+        run: flake8 src/ test/
+      - name: Run Unit Tests
+        run: pytest test/ --ignore=test/test_forked_sim.py
       - name: Run Fork Simulation
         run: |
           ./scripts/simulate_fork.sh &

--- a/infra/Dockerfile
+++ b/infra/Dockerfile
@@ -37,6 +37,7 @@ WORKDIR /home/appuser
 
 # Copy installed dependencies from the builder stage
 COPY --from=builder /home/appuser/.local /home/appuser/.local
+RUN chown -R appuser:appuser /home/appuser
 
 # Copy the application source code
 COPY ./src ./src

--- a/src/adapters/mempool.py
+++ b/src/adapters/mempool.py
@@ -5,7 +5,7 @@ import websockets
 from websockets.exceptions import ConnectionClosed
 
 from src.core.config import settings
-from src.core.kill import check, KillSwitchActiveError, is_kill_switch_active
+from src.core.kill import check, KillSwitchActiveError
 from src.core.logger import get_logger
 
 log = get_logger(__name__)
@@ -36,10 +36,11 @@ class MempoolAdapter:
             raise
 
     async def stream_transactions(self):
-        while not is_kill_switch_active():
+        while True:
             try:
                 check()
             except KillSwitchActiveError:
+                log.critical("MEMPOOL_ABORTED_BY_KILL_SWITCH")
                 break
             if not self.connection or self.connection.closed:
                 try:
@@ -66,5 +67,4 @@ class MempoolAdapter:
                 log.error("MEMPOOL_STREAM_ERROR", error=str(e))
                 await asyncio.sleep(1)
 
-        log.critical("MEMPOOL_ABORTED_BY_KILL_SWITCH")
         return

--- a/src/adapters/mock.py
+++ b/src/adapters/mock.py
@@ -8,7 +8,7 @@ from typing import List, Dict
 from decimal import Decimal
 
 from src.core.tx import TransactionManager, TransactionKillSwitchError
-from src.core.kill import check, KillSwitchActiveError, is_kill_switch_active
+from src.core.kill import check, KillSwitchActiveError
 from src.core.logger import get_logger
 
 log = get_logger(__name__)

--- a/src/core/agent.py
+++ b/src/core/agent.py
@@ -9,7 +9,7 @@ from typing import Dict
 
 from src.core.state import State
 from src.strategies.base import AbstractStrategy
-from src.core.kill import is_kill_switch_active, check, KillSwitchActiveError
+from src.core.kill import check, KillSwitchActiveError
 from src.core.logger import get_logger, set_cycle_counter
 from src.core import drp
 from src.core.config import settings

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -38,6 +38,7 @@ class Settings(BaseSettings):
     REDIS_URL: AnyUrl = "redis://localhost:6379/0"
     MANUAL_APPROVAL: bool = False
     CONTROL_API_TOKEN: str | None = None
+    MUTATION_TTL_SECONDS: int = 3600
 
     class Config:
         env_file = ".env"

--- a/src/core/drp.py
+++ b/src/core/drp.py
@@ -1,69 +1,36 @@
-# /src/core/drp.py
-
-import os, json
-from pathlib import Path
-from datetime import datetime, timezone
+from __future__ import annotations
+import json
 import aiofiles
-from google.cloud import storage
-from google.api_core.exceptions import GoogleAPICallError
+from datetime import datetime, timezone
+from pathlib import Path
 
 from src.core.state import State
 from src.core.logger import get_logger, SNAPSHOTS_TAKEN
 from src.core.config import settings
-from src.core.kill import get_gcs_client
 
 log = get_logger(__name__)
-LOCAL_DIR = Path("./.drp_snapshots")
-LAST_FILE = LOCAL_DIR / "last_snapshot.ts"
-USE_GCS = bool(os.getenv("GOOGLE_APPLICATION_CREDENTIALS"))
-GCS_BUCKET = f"{settings.GCP_PROJECT_ID}-mev-og-state" if USE_GCS and settings.GCP_PROJECT_ID else None
+SNAPSHOT_DIR = Path(settings.SESSION_DIR) / "snapshots"
 
 async def save_snapshot(state: State) -> str:
+    """Persist state to a timestamped JSON snapshot."""
+    SNAPSHOT_DIR.mkdir(parents=True, exist_ok=True)
     ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-    filename = f"{state.session_id}_{ts}.json"
-    payload = state.model_dump_json(indent=2)
-
-    # Upload to GCS or write locally
-    if USE_GCS and GCS_BUCKET:
-        client = get_gcs_client()
-        blob = client.bucket(GCS_BUCKET).blob(f"drp/{filename}")
-        try:
-            await aiofiles.threadpool.wrap(blob.upload_from_string)(payload, content_type="application/json")
-            path = f"gs://{GCS_BUCKET}/drp/{filename}"
-            log.info("DRP_SNAPSHOT_GCS", path=path)
-        except GoogleAPICallError as e:
-            log.error("DRP_GCS_FAIL", error=str(e))
-            raise
-    else:
-        LOCAL_DIR.mkdir(parents=True, exist_ok=True)
-        fp = LOCAL_DIR / filename
-        async with aiofiles.open(fp, "w") as f:
-            await f.write(payload)
-        path = str(fp)
-        log.info("DRP_SNAPSHOT_LOCAL", path=path)
-
-    # Record last snapshot timestamp
-    LOCAL_DIR.mkdir(parents=True, exist_ok=True)
-    async with aiofiles.open(LAST_FILE, "w") as f:
-        await f.write(ts)
+    path = SNAPSHOT_DIR / f"{state.session_id}_{ts}.json"
+    async with aiofiles.open(path, "w") as f:
+        await f.write(state.model_dump_json(indent=2))
     SNAPSHOTS_TAKEN.inc()
-    return path
+    ttl = getattr(settings, "MUTATION_TTL_SECONDS", 0)
+    if ttl:
+        now = datetime.now().timestamp()
+        for fp in SNAPSHOT_DIR.glob("*.json"):
+            if now - fp.stat().st_mtime > ttl:
+                fp.unlink(missing_ok=True)
+    log.info("DRP_SNAPSHOT_SAVED", path=str(path))
+    return str(path)
 
 async def load_snapshot(path: str) -> State:
-    if USE_GCS and path.startswith("gs://"):
-        client = get_gcs_client()
-        bucket, _, blob_name = path[5:].partition("/")
-        blob = client.bucket(bucket).blob(blob_name)
-        data = await aiofiles.threadpool.wrap(blob.download_as_text)()
-    else:
-        async with aiofiles.open(path, "r") as f:
-            data = await f.read()
+    """Load a snapshot file back into a State object."""
+    async with aiofiles.open(path, "r") as f:
+        data = await f.read()
     obj = json.loads(data)
     return State.model_validate(obj)
-
-async def get_last_snapshot_timestamp() -> str:
-    try:
-        async with aiofiles.open(LAST_FILE, "r") as f:
-            return await f.read()
-    except FileNotFoundError:
-        return "never"

--- a/src/core/kill.py
+++ b/src/core/kill.py
@@ -2,7 +2,7 @@
 import os
 from datetime import datetime, timezone
 from google.cloud import storage
-from google.api_core.exceptions import NotFound, GoogleAPICallError
+from google.api_core.exceptions import GoogleAPICallError
 from src.core.config import settings
 from src.core.logger import get_logger, KILL_TRIGGERED
 import sentry_sdk

--- a/src/core/mutation.py
+++ b/src/core/mutation.py
@@ -2,16 +2,23 @@ import asyncio
 import json
 import os
 import difflib
+import time
 from copy import deepcopy
 
 from src.core import drp
-from src.core.logger import get_logger, MUTATION_ATTEMPT, MUTATION_APPROVED
+from src.core.logger import (
+    get_logger,
+    MUTATION_ATTEMPT,
+    MUTATION_APPROVED,
+    MUTATION_REVERTED,
+)
 from src.core.kill import check
 from src.core.config import settings
 import sentry_sdk
 
 log = get_logger(__name__)
 APPROVAL_FILE = os.path.join(settings.SESSION_DIR, "manual_mutation.approved")
+APPROVAL_DIR = os.path.join(settings.SESSION_DIR, "mutation_approvals")
 
 async def sandboxed_mutate(strategy, state, adapters):
     """Execute strategy.mutate in a sandbox with DRP snapshots and audit."""
@@ -27,8 +34,31 @@ async def sandboxed_mutate(strategy, state, adapters):
     sentry_sdk.capture_message("Mutation executed")
     if settings.MANUAL_APPROVAL:
         log.warning("AWAITING_MANUAL_APPROVAL")
+        start = time.time()
+        ttl = getattr(settings, "MUTATION_TTL_SECONDS", 0)
         while not os.path.exists(APPROVAL_FILE):
             await asyncio.sleep(1)
+            if ttl and time.time() - start > ttl:
+                state = await drp.load_snapshot(pre)
+                await drp.save_snapshot(state)
+                MUTATION_REVERTED.inc()
+                log.warning("MUTATION_AUTO_REVERTED", snapshot=pre)
+                return None
         os.remove(APPROVAL_FILE)
+
+    now = time.time()
+    ttl = getattr(settings, "MUTATION_TTL_SECONDS", 0)
+    if ttl:
+        for fname in os.listdir(APPROVAL_DIR):
+            if fname.endswith(".pending.json"):
+                fp = os.path.join(APPROVAL_DIR, fname)
+                if now - os.path.getmtime(fp) > ttl:
+                    os.remove(fp)
+                    state = await drp.load_snapshot(pre)
+                    await drp.save_snapshot(state)
+                    MUTATION_REVERTED.inc()
+                    log.warning("MUTATION_AUTO_REVERTED", snapshot=pre, pending=fname)
+                    return None
+
     MUTATION_APPROVED.inc()
     return result

--- a/test/test_control_api.py
+++ b/test/test_control_api.py
@@ -1,0 +1,36 @@
+import os
+import asyncio
+import pytest
+from fastapi.testclient import TestClient
+
+from src.core.control_api import app
+from src.core.config import settings
+from src.core import drp
+from src.core.state import State
+from src.core.kill import KILL_SWITCH_FILE
+
+@pytest.fixture(autouse=True)
+def cleanup():
+    if os.path.exists(KILL_SWITCH_FILE):
+        os.remove(KILL_SWITCH_FILE)
+    yield
+    if os.path.exists(KILL_SWITCH_FILE):
+        os.remove(KILL_SWITCH_FILE)
+
+@pytest.mark.asyncio
+async def test_toggle_and_restore(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, "CONTROL_API_TOKEN", "tok")
+    monkeypatch.setattr(drp, "SNAPSHOT_DIR", tmp_path)
+    client = TestClient(app)
+
+    state = State()
+    path = await drp.save_snapshot(state)
+
+    r = client.post("/kill/toggle", headers={"Authorization": "Bearer tok"}, json={"reason": "t"})
+    assert r.status_code == 200 and r.json()["kill_switch_active"] is True
+    r = client.post("/kill/toggle", headers={"Authorization": "Bearer tok"}, json={"reason": "t"})
+    assert r.status_code == 200 and r.json()["kill_switch_active"] is False
+
+    r = client.post("/drp/restore", headers={"Authorization": "Bearer tok"}, json={"snapshot_path": path})
+    assert r.status_code == 200
+    assert r.json()["session_id"] == str(state.session_id)

--- a/test/test_drp.py
+++ b/test/test_drp.py
@@ -2,16 +2,31 @@ import os
 import json
 import asyncio
 import importlib
+import time
 import pytest
 
 from src.core.state import State
 from src.core import drp
+from src.core.config import settings
 
 @pytest.mark.asyncio
 async def test_snapshot_roundtrip(tmp_path, monkeypatch):
-    monkeypatch.setattr(drp, "LOCAL_DIR", tmp_path)
+    monkeypatch.setattr(drp, "SNAPSHOT_DIR", tmp_path)
     state = State()
     path = await drp.save_snapshot(state)
     assert os.path.exists(path)
     loaded = await drp.load_snapshot(path)
     assert loaded.session_id == state.session_id
+
+
+@pytest.mark.asyncio
+async def test_snapshot_ttl_cleanup(tmp_path, monkeypatch):
+    monkeypatch.setattr(drp, "SNAPSHOT_DIR", tmp_path)
+    monkeypatch.setattr(settings, "MUTATION_TTL_SECONDS", 1)
+    state = State()
+    first = await drp.save_snapshot(state)
+    os.utime(first, (time.time() - 2, time.time() - 2))
+    await asyncio.sleep(1.1)
+    second = await drp.save_snapshot(state)
+    assert os.path.exists(second)
+    assert not os.path.exists(first)

--- a/test/test_replay_protection.py
+++ b/test/test_replay_protection.py
@@ -1,0 +1,58 @@
+import asyncio
+import os
+import pytest
+
+from src.core.tx import TransactionManager
+from src.core.nonce_manager import NonceManager
+from src.core.config import settings
+
+class DummyEth:
+    async def estimate_gas(self, _):
+        return 21000
+    async def send_raw_transaction(self, _):
+        return b'hash'
+    async def gas_price(self):
+        return 1
+    async def max_priority_fee(self):
+        return 1
+    async def get_transaction_count(self, _):
+        return 0
+    class account:
+        @staticmethod
+        def sign_transaction(tx, key):
+            return type('S', (), {'rawTransaction': b'raw'})()
+
+class DummyW3:
+    def __init__(self):
+        self.eth = DummyEth()
+
+class DummyLock:
+    def __init__(self):
+        self._lock = asyncio.Lock()
+    async def __aenter__(self):
+        await self._lock.acquire()
+    async def __aexit__(self, exc_type, exc, tb):
+        self._lock.release()
+
+class DummyRedis:
+    def lock(self, name, timeout=10):
+        return DummyLock()
+    async def close(self):
+        pass
+
+@pytest.mark.asyncio
+async def test_nonce_collision_handled(tmp_path, monkeypatch):
+    monkeypatch.setattr(settings, 'SESSION_DIR', str(tmp_path))
+    tm = TransactionManager()
+    tm.w3 = DummyW3()
+    tm.account = type('A', (), {'key': '0x0'})()
+    tm.address = '0xabc'
+    tm.nonce_manager = NonceManager(tm.w3, tm.address)
+    tm.redis = DummyRedis()
+    await tm.nonce_manager.initialize()
+
+    async def send():
+        await tm.build_and_send_transaction({'to': '0x1'})
+
+    await asyncio.gather(send(), send())
+    assert await tm.nonce_manager.get() == 2


### PR DESCRIPTION
## Summary
- overhaul DRP module for JSON snapshots in SESSION_DIR
- enforce kill guards and remove stale kill-switch state
- add mutation TTL handling with auto rollback
- run fork simulation and lint/tests in CI
- run containers as non-root user
- expand env vars example
- add tests for control API, DRP TTL cleanup and nonce replay protection

## Testing
- `flake8 src test`
- `pytest -q` *(fails: ModuleNotFoundError for several deps)*

------
https://chatgpt.com/codex/tasks/task_e_68491c54e550832cb24baed09abd8356